### PR TITLE
format postcode before searching

### DIFF
--- a/Fmas12d.Ui/src/app/services/postcode-validation/postcode-validation.service.ts
+++ b/Fmas12d.Ui/src/app/services/postcode-validation/postcode-validation.service.ts
@@ -20,6 +20,14 @@ export class PostcodeValidationService {
 
   public searchPostcode(postcode: string): Observable<AddressResult> {
 
+    // format the supplied postcode so that it contains a space
+    postcode = postcode.trim();
+    if (postcode.indexOf(' ') === -1 && postcode.length > 3) {
+      const inwardCode = postcode.substr(postcode.length - 3, 3);
+      const outwardCode = postcode.substr(0, postcode.length - 3);
+      postcode = `${outwardCode} ${inwardCode}`;
+    }
+
     // Dummy data for postcode searching !!
 
     const addresses = from([


### PR DESCRIPTION
[AB#10325](https://einnovationteam-mlcsu.visualstudio.com/34fed099-e327-491e-a91e-4822ff25db86/_workitems/edit/10325)
Allows searching of postcodes with or without spaces separating the outward and inward codes (WS11 5UB or WS115UB)