### PR TITLE
Adding dummy postcode request for WS11 5UB

### DIFF
--- a/Fmas12d.Api/appsettings.AimesUat.json
+++ b/Fmas12d.Api/appsettings.AimesUat.json
@@ -1,4 +1,5 @@
-{
+{  
+  "AddressSearchAPiKey": "",
   "ConnectionStrings": {
     "Fmas12d": "Server=einno-tsql23;Initial Catalog=fmas12d;Integrated Security=True;MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;Application Name=Fmas12dApi;"
   },

--- a/Fmas12d.Api/appsettings.AzureDevelopment.json
+++ b/Fmas12d.Api/appsettings.AzureDevelopment.json
@@ -1,4 +1,5 @@
 {
+  "AddressSearchAPiKey": "kB2tOMo3NEinPq3KNStTKg22546",  
   "ConnectionStrings": {
     "Fmas12d": "Server=tcp:fmas12d-development.database.windows.net,1433;Initial Catalog=fmas12d-development;Persist Security Info=False;User ID=fmas12d-development-api;Password=5j6bzWavbbs8TCh9kKTK;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Application Name=Fmas12dApi;"
   },

--- a/Fmas12d.Api/appsettings.DisableAuthentication.json
+++ b/Fmas12d.Api/appsettings.DisableAuthentication.json
@@ -1,3 +1,3 @@
 {
-  
+  "AddressSearchAPiKey": ""  
 }

--- a/Fmas12d.Api/appsettings.json
+++ b/Fmas12d.Api/appsettings.json
@@ -1,10 +1,9 @@
 {
-  "AllowedHosts": "*",
+  "AddressSearchEndpoint": "https://api.getaddress.io/find/",
+  "AllowedHosts": "*",  
   "CcgApiEndpoint": "https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/CCG_APR_2019_EN_NC/FeatureServer/0/query?where=1%3D1&outFields=*&outSR=4326&f=json",
   "GpPracticeApiEndpoint": "https://directory.spineservices.nhs.uk/ORD/2-0-0/organisations?PrimaryRoleId=RO177&Limit=1000",
   "PostcodesIoEndpoint": "https://api.postcodes.io/postcodes/",
-  "AddressSearchEndpoint": "https://api.getaddress.io/find/",
-  "AddressSearchAPiKey": "kB2tOMo3NEinPq3KNStTKg22546",  
   "ConnectionStrings": {
     "Fmas12d": "Server=localhost;DataBase=Fmas12d;Trusted_Connection=true;MultipleActiveResultSets=true;Application Name=Fmas12dApi;"
   },

--- a/Fmas12d.Business/Models/SearchModels/PostcodeIoSearchErrorResult.cs
+++ b/Fmas12d.Business/Models/SearchModels/PostcodeIoSearchErrorResult.cs
@@ -1,0 +1,7 @@
+namespace Fmas12d.Business.Models.SearchModels
+{
+    public class PostcodeIoSearchErrorResult
+    {
+        public string Message { get; set; }    
+    }
+}

--- a/Fmas12d.Business/Services/LocationDetailService.cs
+++ b/Fmas12d.Business/Services/LocationDetailService.cs
@@ -43,12 +43,14 @@ namespace Fmas12d.Business.Services
 
       using HttpResponseMessage response = await client.GetAsync(uri);
       string content = await response.Content.ReadAsStringAsync();
-      try {
+      try
+      {
         convertedResult = JsonConvert.DeserializeObject<PostcodeIoResult>(content);
         Location modelPostcode = new Location(convertedResult);
         return modelPostcode;
       }
-      catch {
+      catch
+      {
         throw new ModelStateException("postcode",
           $"{convertedResult.Error} {stringPostcode}");
       }
@@ -64,25 +66,139 @@ namespace Fmas12d.Business.Services
 
       string apiKey = _configuration.GetValue("AddressSearchApiKey", "");
 
-      string uri = $"{endpoint}{stringPostcode}?api-key={apiKey}&sort=true";
-
-      using HttpResponseMessage response = await client.GetAsync(uri);
-
-      if (response.IsSuccessStatusCode){
-        string content = await response.Content.ReadAsStringAsync();
-        try {
-          convertedResult = JsonConvert.DeserializeObject<PostcodeIoSearchResult>(content);
-          return convertedResult;
+      if (apiKey == "")
+      {
+        if (string.Compare(stringPostcode.Replace(" ", ""), "WS115UB", true) == 0)
+        {
+          PostcodeIoSearchResult dummyResult = new PostcodeIoSearchResult()
+          {
+            Latitude = 52.707441m,
+            Longitude = -2.014768m,
+            Addresses = new string[]
+            {
+              "1 Blake Close, Cannock, Staffordshire",
+              "1a Blake Close, Cannock, Staffordshire",
+              "2 Blake Close, Cannock, Staffordshire",
+              "2a Blake Close, Cannock, Staffordshire",
+              "3 Blake Close, Cannock, Staffordshire",
+              "3a Blake Close, Cannock, Staffordshire",
+              "4 Blake Close, Cannock, Staffordshire",
+              "5 Blake Close, Cannock, Staffordshire",
+              "6 Blake Close, Cannock, Staffordshire",
+              "7 Blake Close, Cannock, Staffordshire",
+              "8 Blake Close, Cannock, Staffordshire",
+              "9 Blake Close, Cannock, Staffordshire",
+              "10 Blake Close, Cannock, Staffordshire",
+              "11 Blake Close, Cannock, Staffordshire",
+              "12 Blake Close, Cannock, Staffordshire",
+              "13 Blake Close, Cannock, Staffordshire",
+              "14 Blake Close, Cannock, Staffordshire",
+              "15 Blake Close, Cannock, Staffordshire",
+              "16 Blake Close, Cannock, Staffordshire",
+              "17 Blake Close, Cannock, Staffordshire",
+              "18 Blake Close, Cannock, Staffordshire",
+              "19 Blake Close, Cannock, Staffordshire",
+              "20 Blake Close, Cannock, Staffordshire",
+              "21 Blake Close, Cannock, Staffordshire",
+              "21a Blake Close, Cannock, Staffordshire",
+              "22 Blake Close, Cannock, Staffordshire",
+              "23 Blake Close, Cannock, Staffordshire",
+              "24 Blake Close, Cannock, Staffordshire",
+              "25 Blake Close, Cannock, Staffordshire",
+              "26 Blake Close, Cannock, Staffordshire",
+              "27 Blake Close, Cannock, Staffordshire",
+              "28 Blake Close, Cannock, Staffordshire",
+              "35 Blake Close, Cannock, Staffordshire",
+              "36 Blake Close, Cannock, Staffordshire",
+              "37 Blake Close, Cannock, Staffordshire",
+              "38 Blake Close, Cannock, Staffordshire",
+              "39 Blake Close, Cannock, Staffordshire",
+              "40 Blake Close, Cannock, Staffordshire",
+              "41 Blake Close, Cannock, Staffordshire",
+              "42 Blake Close, Cannock, Staffordshire",
+              "43 Blake Close, Cannock, Staffordshire",
+              "44 Blake Close, Cannock, Staffordshire",
+              "45 Blake Close, Cannock, Staffordshire",
+              "46 Blake Close, Cannock, Staffordshire",
+              "47 Blake Close, Cannock, Staffordshire",
+              "48 Blake Close, Cannock, Staffordshire",
+              "49 Blake Close, Cannock, Staffordshire",
+              "50 Blake Close, Cannock, Staffordshire",
+              "51 Blake Close, Cannock, Staffordshire",
+              "52 Blake Close, Cannock, Staffordshire",
+              "53 Blake Close, Cannock, Staffordshire",
+              "54 Blake Close, Cannock, Staffordshire",
+              "55 Blake Close, Cannock, Staffordshire",
+              "56 Blake Close, Cannock, Staffordshire",
+              "57 Blake Close, Cannock, Staffordshire",
+              "58 Blake Close, Cannock, Staffordshire",
+              "59 Blake Close, Cannock, Staffordshire",
+              "60 Blake Close, Cannock, Staffordshire",
+              "61 Blake Close, Cannock, Staffordshire",
+              "62 Blake Close, Cannock, Staffordshire",
+              "63 Blake Close, Cannock, Staffordshire",
+              "64 Blake Close, Cannock, Staffordshire",
+              "65 Blake Close, Cannock, Staffordshire",
+              "66 Blake Close, Cannock, Staffordshire",
+              "67 Blake Close, Cannock, Staffordshire",
+              "68 Blake Close, Cannock, Staffordshire",
+              "69 Blake Close, Cannock, Staffordshire",
+              "70 Blake Close, Cannock, Staffordshire",
+              "71 Blake Close, Cannock, Staffordshire",
+              "72 Blake Close, Cannock, Staffordshire",
+              "73 Blake Close, Cannock, Staffordshire",
+              "74 Blake Close, Cannock, Staffordshire",
+              "75 Blake Close, Cannock, Staffordshire",
+              "76 Blake Close, Cannock, Staffordshire",
+              "77 Blake Close, Cannock, Staffordshire",
+              "78 Blake Close, Cannock, Staffordshire",
+              "79 Blake Close, Cannock, Staffordshire",
+              "80 Blake Close, Cannock, Staffordshire",
+              "81 Blake Close, Cannock, Staffordshire",
+              "82 Blake Close, Cannock, Staffordshire",
+              "83 Blake Close, Cannock, Staffordshire",
+              "84 Blake Close, Cannock, Staffordshire",
+              "85 Blake Close, Cannock, Staffordshire",
+              "86 Blake Close, Cannock, Staffordshire",
+              "87 Blake Close, Cannock, Staffordshire",
+              "88 Blake Close, Cannock, Staffordshire",
+              "89 Blake Close, Cannock, Staffordshire",
+              "90 Blake Close, Cannock, Staffordshire"
+            }
+          };
+          return dummyResult;
         }
-        catch {
-          throw new ModelStateException("postcode",
-            $"Error searching {stringPostcode}");
+        else
+        {
+          throw new ModelStateException("postcode", $"Error searching {stringPostcode}");
         }
-      } else {
-        throw new ModelStateException("postcode", "boom");
       }
+      else
+      {
+        string uri = $"{endpoint}{stringPostcode}?api-key={apiKey}&sort=true";
+        Serilog.Log.Information(uri);
+        using HttpResponseMessage response = await client.GetAsync(uri);
+        string content = await response.Content.ReadAsStringAsync();
 
-
+        if (response.IsSuccessStatusCode)
+        {          
+          try
+          {
+            convertedResult = JsonConvert.DeserializeObject<PostcodeIoSearchResult>(content);
+            return convertedResult;
+          }
+          catch
+          {
+            throw new ModelStateException("postcode", $"Error searching {stringPostcode}");
+          }
+        }
+        else
+        {
+          PostcodeIoSearchErrorResult errorResult = 
+            JsonConvert.DeserializeObject<PostcodeIoSearchErrorResult>(content);
+          throw new ModelStateException("postcode", errorResult.Message);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
The address list for WS11 5UB is returned if AddressSearchAPiKey
is blank in the appsettings json file and WS11 5UB is searched for
- AimesUat: no API key
- AzureDevelopment: test API key
- DisableAuthentication: no API key
- appSettings: removed API key